### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cd harvest
 
 yarn
 
-yarn install -g webassembly // tooling
+yarn global add webassembly // tooling
 
 yarn start // development
 yarn build // production


### PR DESCRIPTION
yarn install -g webassembly
yarn install v0.24.6
error `install` has been replaced with `add` to add new dependencies. Run "yarn global add webassembly" instead.